### PR TITLE
Upgrade to Bevy 0.16.1, remove capture plugin, implement double buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "accesskit"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+checksum = "becf0eb5215b6ecb0a739c31c21bd83c4f326524c9b46b7e882d77559b60a529"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+checksum = "d0bf66a7bf0b7ea4fd7742d50b64782a88f99217cf246b3f93b4162528dde520"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.2",
+ "hashbrown",
  "immutable-chunkmap",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+checksum = "09e230718177753b4e4ad9e1d9f6cfc2f4921212d4c1c480b253f526babb258d"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.15.2",
+ "hashbrown",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -35,13 +35,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+checksum = "65178f3df98a51e4238e584fcb255cb1a4f9111820848eeddd37663be40a625f"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.15.2",
+ "hashbrown",
  "paste",
  "static_assertions",
  "windows 0.58.0",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+checksum = "34d941bb8c414caba6e206de669c7dc0dbeb305640ea890772ee422a40e6b89f"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -77,20 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "const-random",
- "getrandom 0.2.15",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,12 +84,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
@@ -230,12 +210,14 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -280,7 +262,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -301,6 +283,9 @@ name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "async-tungstenite"
@@ -345,6 +330,9 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "atomic_refcell"
@@ -747,18 +735,18 @@ dependencies = [
 
 [[package]]
 name = "bevy"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaad7fe854258047680c51c3cacb804468553c04241912f6254c841c67c0198"
+checksum = "4b8369c16b7c017437021341521f8b4a0d98e1c70113fb358c3258ae7d661d79"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245a938f754f70a380687b89f1c4dac75b62d58fae90ae969fcfb8ecd91ed879"
+checksum = "ed3561712cf49074d89e9989bfc2e6c6add5d33288f689db9a0c333300d2d004"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -769,19 +757,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e2b3e4e6cb4df085b941b105f2c790901e34c8571e02342f8e96acdf7cf7d1"
+checksum = "49796627726d0b9a722ad9a0127719e7c1868f474d6575ec0f411e8299c4d7bb"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
+ "bevy_mesh",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
@@ -791,38 +779,44 @@ dependencies = [
  "derive_more",
  "downcast-rs",
  "either",
- "petgraph",
+ "petgraph 0.7.1",
  "ron",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
  "thread_local",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_app"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ac033a388b8699d241499a43783a09e6a3bab2430f1297c6bd4974095efb3f"
+checksum = "4491cc4c718ae76b4c6883df58b94cc88b32dcd894ea8d5b603c7c7da72ca967"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
+ "cfg-if",
  "console_error_panic_hook",
  "ctrlc",
- "derive_more",
  "downcast-rs",
+ "log",
+ "thiserror 2.0.11",
+ "variadics_please",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "bevy_asset"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fd901b3be016088c4dda2f628bda96b7cb578b9bc8ae684bbf30bec0a9483e"
+checksum = "f56111d9b88d8649f331a667d9d72163fb26bd09518ca16476d238653823db1e"
 dependencies = [
  "async-broadcast",
  "async-fs",
@@ -831,6 +825,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset_macros",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -849,6 +844,8 @@ dependencies = [
  "ron",
  "serde",
  "stackfuture",
+ "thiserror 2.0.11",
+ "tracing",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -857,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6725a785789ece8d8c73bba25fdac5e50494d959530e89565bbcea9f808b7181"
+checksum = "a4cca3e67c0ec760d8889d42293d987ce5da92eaf9c592bf5d503728a63b276d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -869,39 +866,27 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30af4b6a91c8e08f623b0cdc53ce5b8f731c78af6ef728cdfc06dc61eda164c4"
+checksum = "f2b4f6f2a5c6c0e7c6825e791d2a061c76c2d6784f114c8f24382163fabbfaaa"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
  "bevy_transform",
- "bevy_utils",
  "cpal",
  "rodio",
-]
-
-[[package]]
-name = "bevy_capture"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44680e17a0f133bbc8ee9093c27dba76a7e2b6d4d4d1bba6afac61abce865dce"
-dependencies = [
- "bevy",
- "crossbeam-channel",
- "image",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_color"
-version = "0.15.4"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87b7137ffa9844ae542043769fb98c35efbf2f8a8429ff2a73d8ef30e58baaa"
+checksum = "5c101cbe1e26b8d701eb77263b14346e2e0cbbd2a6e254b9b1aead814e5ca8d3"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -909,55 +894,45 @@ dependencies = [
  "derive_more",
  "encase",
  "serde",
+ "thiserror 2.0.11",
  "wgpu-types",
 ]
 
 [[package]]
-name = "bevy_core"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9ce8da8e4016f63c1d361b52e61aaf4348c569829c74f1a5bbedfd8d3d57a3"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_tasks",
- "bevy_utils",
- "uuid",
-]
-
-[[package]]
 name = "bevy_core_pipeline"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0ff0f4723f30a5a6578915dbfe0129f2befaec8438dde70ac1fb363aee01f5"
+checksum = "59ed46363cad80dc00f08254c3015232bd6f640738403961c6d63e7ecfc61625"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
  "bitflags 2.9.0",
- "derive_more",
+ "bytemuck",
  "nonmax",
  "radsort",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d94761ce947b0a2402fd949fe1e7a5b1535293130ba4cd9893be6295d4680a"
+checksum = "1b837bf6c51806b10ebfa9edf1844ad80a3a0760d6c5fac4e90761df91a8901a"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -966,48 +941,55 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e83c65979f063b593917ab9b1d7328c5854dba4b6ddf1ab78156c0105831fdf"
+checksum = "48797366f312a8f31e237d08ce3ee70162591282d2bfe7c5ad8be196fb263e55"
 dependencies = [
  "bevy_app",
- "bevy_core",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_tasks",
  "bevy_time",
  "bevy_utils",
  "const-fnv1a-hash",
+ "log",
+ "serde",
  "sysinfo",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1597106cc01e62e6217ccb662e0748b2ce330893f27c7dc17bac33e0bb99bca9"
+checksum = "3c2bf6521aae57a0ec3487c4bfb59e36c4a378e834b626a4bea6a885af2fdfe7"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "bitflags 2.9.0",
+ "bumpalo",
  "concurrent-queue",
  "derive_more",
  "disqualified",
  "fixedbitset 0.5.7",
+ "indexmap",
+ "log",
  "nonmax",
- "petgraph",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f453adf07712b39826bc5845e5b0887ce03204ee8359bbe6b40a9afda60564a1"
+checksum = "38748d6f3339175c582d751f410fb60a93baf2286c3deb7efebb0878dce7f413"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1017,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37ad69d36bb9e8479a88d481ef9748f5d7ab676040531d751d3a44441dcede7"
+checksum = "8148f4edee470a2ea5cad010184c492a4c94c36d7a7158ea28e134ea87f274ab"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -1027,24 +1009,26 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a737451ccd6be5da68fbba5d984328b8a82eebd16c1fda0bec840090a3d454fd"
+checksum = "97efef87c631949e67d06bb5d7dfd2a5f936b3b379afb6b1485b08edbb219b87"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
+ "bevy_platform",
  "bevy_time",
  "bevy_utils",
- "derive_more",
  "gilrs",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1614516d0922ad60e87cc39658422286ed684aaf4b3162d25051bc105eed814"
+checksum = "7823154a9682128c261d8bddb3a4d7192a188490075c527af04520c2f0f8aad6"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1062,13 +1046,14 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bytemuck",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edb9e0dca64e0fc9d6b1d9e6e2178396e339e3e2b9f751e2504e3ea4ddf4508"
+checksum = "f378f3b513218ddc78254bbe76536d9de59c1429ebd0c14f5d8f2a25812131ad"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1078,94 +1063,106 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8364f34bc08fe067ce32418e22ee96e177101dbf1bc00803aaeb2b262615be"
+checksum = "10a080237c0b8842ccc15a06d3379302c68580eeea4497b1c7387e470eda1f07"
 dependencies = [
  "base64 0.22.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_math",
+ "bevy_mesh",
  "bevy_pbr",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_scene",
  "bevy_tasks",
  "bevy_transform",
  "bevy_utils",
- "derive_more",
+ "fixedbitset 0.5.7",
  "gltf",
+ "itertools 0.14.0",
  "percent-encoding",
  "serde",
  "serde_json",
  "smallvec",
-]
-
-[[package]]
-name = "bevy_hierarchy"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ced04e04437d0a439fe4722544c2a4678c1fe3412b57ee489d817c11884045"
-dependencies = [
- "bevy_app",
- "bevy_core",
- "bevy_ecs",
- "bevy_reflect",
- "bevy_utils",
- "disqualified",
- "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_image"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b384d1ce9c87f6151292a76233897a628c2a50b3560487c4d74472225d49826"
+checksum = "65e6e900cfecadbc3149953169e36b9e26f922ed8b002d62339d8a9dc6129328"
 dependencies = [
+ "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "bitflags 2.9.0",
  "bytemuck",
- "derive_more",
  "futures-lite",
+ "guillotiere",
+ "half",
  "image",
  "ktx2",
+ "rectangle-pack",
  "ruzstd",
  "serde",
- "wgpu",
+ "thiserror 2.0.11",
+ "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52589939ca09695c69d629d166c5edf1759feaaf8f2078904aae9c33d08f5c3"
+checksum = "18d6b6516433f6f7d680f648d04eb1866bb3927a1782d52f74831b62042f3cd1"
 dependencies = [
  "bevy_app",
- "bevy_core",
  "bevy_ecs",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
  "derive_more",
+ "log",
  "smol_str",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "bevy_input_focus"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2d079fda74d1416e0a57dac29ea2b79ff77f420cd6b87f833d3aa29a46bc4d"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_window",
+ "log",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e0c1d980d276e11558184d0627c8967ad8b70dab3e54a0f377bb53b98515b6"
+checksum = "857da8785678fde537d02944cd20dec9cafb7d4c447efe15f898dc60e733cacd"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -1173,7 +1170,6 @@ dependencies = [
  "bevy_asset",
  "bevy_audio",
  "bevy_color",
- "bevy_core",
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_diagnostic",
@@ -1181,13 +1177,14 @@ dependencies = [
  "bevy_gilrs",
  "bevy_gizmos",
  "bevy_gltf",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
  "bevy_picking",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect",
  "bevy_render",
@@ -1206,14 +1203,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381a22e01f24af51536ef1eace94298dd555d06ffcf368125d16317f5f179cb"
+checksum = "d7a61ee8aef17a974f5ca481dcedf0c2bd52670e231d4c4bc9ddef58328865f9"
 dependencies = [
  "android_log-sys",
  "bevy_app",
  "bevy_ecs",
  "bevy_utils",
+ "tracing",
  "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
@@ -1222,10 +1220,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb6ded1ddc124ea214f6a2140e47a78d1fe79b0638dad39419cdeef2e1133f1"
+checksum = "052eeebcb8e7e072beea5031b227d9a290f8a7fbbb947573ab6ec81df0fb94be"
 dependencies = [
+ "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
@@ -1234,25 +1233,29 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2650169161b64f9a93e41f13253701fdf971dc95265ed667d17bea6d2a334f"
+checksum = "68553e0090fe9c3ba066c65629f636bd58e4ebd9444fdba097b91af6cd3e243f"
 dependencies = [
+ "approx",
  "bevy_reflect",
  "derive_more",
  "glam",
- "itertools 0.13.0",
+ "itertools 0.14.0",
+ "libm",
  "rand 0.8.5",
  "rand_distr",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760f3c41b4c61a5f0d956537f454c49f79b8ed0fd0781b1a879ead8e69d95283"
+checksum = "b10399c7027001edbc0406d7d0198596b1f07206c1aae715274106ba5bdcac40"
 dependencies = [
  "bevy_asset",
  "bevy_derive",
@@ -1260,40 +1263,44 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_mikktspace",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
  "bitflags 2.9.0",
  "bytemuck",
- "derive_more",
  "hexasphere",
  "serde",
- "wgpu",
+ "thiserror 2.0.11",
+ "tracing",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226f663401069ded4352ed1472a85bb1f43e2b7305d6a50e53a4f6508168e380"
+checksum = "8bb60c753b968a2de0fd279b76a3d19517695e771edb4c23575c7f92156315de"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d54c840d4352dac51f2a27cf915ac99b2f93db008d8fb1be8d23b09d522acf"
+checksum = "d5e0b4eb871f364a0d217f70f6c41d7fdc6f9f931fa1abbf222180c03d0ae410"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_core_pipeline",
  "bevy_derive",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -1304,25 +1311,28 @@ dependencies = [
  "derive_more",
  "fixedbitset 0.5.7",
  "nonmax",
+ "offset-allocator",
  "radsort",
  "smallvec",
  "static_assertions",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_picking"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2091a495c0f9c8962abb1e30f9d99696296c332b407e1f6fe1fe28aab96a8629"
+checksum = "8ed04757938655ed8094ea1efb533f99063a8b22abffc22010c694d291522850"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_input",
  "bevy_math",
  "bevy_mesh",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_time",
@@ -1330,22 +1340,42 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "crossbeam-channel",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
-name = "bevy_ptr"
-version = "0.15.3"
+name = "bevy_platform"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fe0b0b919146939481a3a7c38864face2c6d0fd2c73ab3d430dc693ecd9b11"
+checksum = "f7573dc824a1b08b4c93fdbe421c53e1e8188e9ca1dd74a414455fe571facb47"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "foldhash",
+ "getrandom 0.2.15",
+ "hashbrown",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "spin",
+ "web-time",
+]
+
+[[package]]
+name = "bevy_ptr"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddbca0a39e88eff2c301dc794ee9d73a53f4b08d47b2c9b5a6aac182fae6217"
+checksum = "daeb91a63a1a4df00aa58da8cc4ddbd4b9f16ab8bb647c5553eb156ce36fa8c2"
 dependencies = [
  "assert_type_match",
+ "bevy_platform",
  "bevy_ptr",
  "bevy_reflect_derive",
  "bevy_utils",
@@ -1353,19 +1383,23 @@ dependencies = [
  "disqualified",
  "downcast-rs",
  "erased-serde",
+ "foldhash",
  "glam",
- "petgraph",
+ "petgraph 0.7.1",
  "serde",
  "smallvec",
  "smol_str",
+ "thiserror 2.0.11",
  "uuid",
+ "variadics_please",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62affb769db17d34ad0b75ff27eca94867e2acc8ea350c5eca97d102bd98709"
+checksum = "40ddadc55fe16b45faaa54ab2f9cb00548013c74812e8b018aa172387103cce6"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1376,23 +1410,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4aa9d7df5c2b65540093b8402aceec0a55d67b54606e57ce2969abe280b4c48"
+checksum = "ef91fed1f09405769214b99ebe4390d69c1af5cdd27967deae9135c550eb1667"
 dependencies = [
  "async-channel",
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_core",
  "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_encase_derive",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_math",
  "bevy_mesh",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render_macros",
  "bevy_tasks",
@@ -1400,13 +1433,16 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
+ "bitflags 2.9.0",
  "bytemuck",
  "codespan-reporting",
  "derive_more",
  "downcast-rs",
  "encase",
+ "fixedbitset 0.5.7",
  "futures-lite",
  "image",
+ "indexmap",
  "js-sys",
  "ktx2",
  "naga",
@@ -1416,6 +1452,9 @@ dependencies = [
  "send_wrapper",
  "serde",
  "smallvec",
+ "thiserror 2.0.11",
+ "tracing",
+ "variadics_please",
  "wasm-bindgen",
  "web-sys",
  "wgpu",
@@ -1423,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3469307d1b5ca5c37b7f9269be033845357412ebad33eace46826e59da592f66"
+checksum = "abd42cf6c875bcf38da859f8e731e119a6aff190d41dd0a1b6000ad57cf2ed3d"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1435,29 +1474,30 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfe819202aa97bbb206d79fef83504b34d45529810563aafc2fe02cc10e3ee4"
+checksum = "5c52ca165200995fe8afd2a1a6c03e4ffee49198a1d4653d32240ea7f217d4ab"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
  "derive_more",
  "serde",
+ "thiserror 2.0.11",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_sprite"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27411a31704117002787c9e8cc1f2f89babf5e67572508aa029366d4643f8d01"
+checksum = "6ccae7bab2cb956fb0434004c359e432a3a1a074a6ef4eb471f1fb099f0b620b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1468,6 +1508,7 @@ dependencies = [
  "bevy_image",
  "bevy_math",
  "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_transform",
@@ -1477,31 +1518,32 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "fixedbitset 0.5.7",
- "guillotiere",
  "nonmax",
  "radsort",
- "rectangle-pack",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_state"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243a72266f81452412f7a3859e5d11473952a25767dc29c8d285660330f007ba"
+checksum = "155d3cd97b900539008cdcaa702f88b724d94b08977b8e591a32536ce66faa8c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_state_macros",
  "bevy_utils",
+ "log",
+ "variadics_please",
 ]
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022eb069dfd64090fd92ba4a7f235383e49aa1c0f4320dab4999b23f67843b36"
+checksum = "2481c1304fd2a1851a0d4cb63a1ce6421ae40f3f0117cbc9882963ee4c9bb609"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1518,13 +1560,14 @@ dependencies = [
  "bevy",
  "bevy_app",
  "bevy_asset",
- "bevy_capture",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_input",
  "bevy_log",
  "bevy_math",
  "bevy_picking",
+ "bevy_platform",
  "bevy_render",
  "bevy_utils",
  "bevy_window",
@@ -1553,33 +1596,41 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028630ddc355563bd567df1076db3515858aa26715ddf7467d2086f9b40e5ab1"
+checksum = "5b674242641cab680688fc3b850243b351c1af49d4f3417a576debd6cca8dcf5"
 dependencies = [
  "async-channel",
  "async-executor",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform",
+ "cfg-if",
  "concurrent-queue",
+ "crossbeam-queue",
+ "derive_more",
  "futures-channel",
  "futures-lite",
+ "heapless",
  "pin-project",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872b0b627cedf6d1bd97b75bc4d59c16f67afdd4f2fed8f7d808a258d6cb982e"
+checksum = "1d76c85366159f5f54110f33321c76d8429cfd8f39638f26793a305dae568b60"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
+ "bevy_log",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1587,45 +1638,52 @@ dependencies = [
  "bevy_utils",
  "bevy_window",
  "cosmic-text",
- "derive_more",
  "serde",
  "smallvec",
  "sys-locale",
+ "thiserror 2.0.11",
+ "tracing",
  "unicode-bidi",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2051ec56301b994f7c182a2a6eb1490038149ad46d95eee715e1a922acdfd9"
+checksum = "bc98eb356c75be04fbbc77bb3d8ffa24c8bacd99f76111cee23d444be6ac8c9c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bevy_platform",
  "bevy_reflect",
- "bevy_utils",
  "crossbeam-channel",
+ "log",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8109b1234b0e58931f51df12bc8895daa69298575cf92da408848f79a4ce201"
+checksum = "df218e440bb9a19058e1b80a68a031c887bcf7bd3a145b55f361359a2fa3100d"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
- "bevy_hierarchy",
+ "bevy_log",
  "bevy_math",
  "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
  "derive_more",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e534590222d044c875bf3511e5d0b3da78889bb21ad797953484ce011af77b46"
+checksum = "ea4a4d2ba51865bc3039af29a26b4f52c48b54cc758369f52004caf4b6f03770"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1635,11 +1693,11 @@ dependencies = [
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_input",
  "bevy_math",
  "bevy_picking",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
@@ -1652,57 +1710,45 @@ dependencies = [
  "nonmax",
  "smallvec",
  "taffy",
+ "thiserror 2.0.11",
+ "tracing",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c2174d43a0de99f863c98a472370047a2bfa7d1e5cec8d9d647fb500905d9d"
+checksum = "94f7a8905a125d2017e8561beefb7f2f5e67e93ff6324f072ad87c5fd6ec3b99"
 dependencies = [
- "ahash",
- "bevy_utils_proc_macros",
- "getrandom 0.2.15",
- "hashbrown 0.14.5",
+ "bevy_platform",
  "thread_local",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "bevy_utils_proc_macros"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94847541f6dd2e28f54a9c2b0e857da5f2631e2201ebc25ce68781cdcb721391"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e1e7c6713c04404a3e7cede48a9c47b76c30efc764664ec1246147f6fb9878"
+checksum = "df7e8ad0c17c3cc23ff5566ae2905c255e6986037fb041f74c446216f5c38431"
 dependencies = [
  "android-activity",
- "bevy_a11y",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
+ "log",
  "raw-window-handle",
+ "serde",
  "smol_str",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e158a73d6d896b1600a61bc115017707ecb467d1a5ad49231c5e58294f6f6e13"
+checksum = "6a5e7f00c6b3b6823df5ec2a5e9067273607208919bc8c211773ebb9643c87f0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1712,11 +1758,12 @@ dependencies = [
  "bevy_asset",
  "bevy_derive",
  "bevy_ecs",
- "bevy_hierarchy",
  "bevy_image",
  "bevy_input",
+ "bevy_input_focus",
  "bevy_log",
  "bevy_math",
+ "bevy_platform",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
@@ -1725,6 +1772,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-channel",
  "raw-window-handle",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -1970,12 +2018,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -2032,6 +2074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -2049,26 +2092,6 @@ name = "const-fnv1a-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.15",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "const_panic"
@@ -2169,18 +2192,18 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.12.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+checksum = "e418dd4f5128c3e93eab12246391c54a20c496811131f85754dc8152ee207892"
 dependencies = [
  "bitflags 2.9.0",
  "fontdb",
  "log",
  "rangemap",
- "rayon",
  "rustc-hash",
  "rustybuzz",
  "self_cell",
+ "smol_str",
  "swash",
  "sys-locale",
  "ttf-parser 0.21.1",
@@ -2232,6 +2255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,20 +2270,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
+name = "crossbeam-queue"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2393,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dpi"
@@ -2487,12 +2506,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -2508,7 +2521,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2563,9 +2576,9 @@ checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "font-types"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
 dependencies = [
  "bytemuck",
 ]
@@ -2874,11 +2887,12 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.29.2"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 dependencies = [
  "bytemuck",
+ "libm",
  "rand 0.8.5",
  "serde",
 ]
@@ -2935,9 +2949,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "glow"
-version = "0.14.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3040,7 +3054,7 @@ checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
 dependencies = [
  "bitflags 2.9.0",
  "gpu-descriptor-types",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3054,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
+checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
 
 [[package]]
 name = "gst-plugin-rtp"
@@ -3464,14 +3478,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
+name = "half"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
- "ahash",
- "allocator-api2",
- "serde",
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3480,7 +3502,9 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3505,6 +3529,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "portable-atomic",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3874,7 +3909,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -3942,6 +3978,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4051,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -4209,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
  "bitflags 2.9.0",
  "block",
@@ -4297,14 +4342,14 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "naga"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
  "bitflags 2.9.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -4312,16 +4357,17 @@ dependencies = [
  "pp-rs",
  "rustc-hash",
  "spirv",
+ "strum",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "unicode-xid",
 ]
 
 [[package]]
 name = "naga_oil"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ea1f080bb359927cd5404d0af1e5e6758f4f2d82ecfbebb0a0c434764e40f1"
+checksum = "f2464f7395decfd16bb4c33fb0cb3b2c645cc60d051bc7fb652d3720bfb20f18"
 dependencies = [
  "bit-set 0.5.3",
  "codespan-reporting",
@@ -4415,7 +4461,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -4597,6 +4643,15 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4854,6 +4909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,6 +5027,16 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
  "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap",
  "serde",
  "serde_derive",
 ]
@@ -5042,6 +5116,21 @@ dependencies = [
  "rustix",
  "tracing",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -5130,7 +5219,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.5",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5265,30 +5354,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "read-fonts"
-version = "0.22.7"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -5430,13 +5499,12 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
 dependencies = [
  "cpal",
  "lewton",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5578,9 +5646,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 dependencies = [
  "twox-hash",
 ]
@@ -5703,9 +5771,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -5788,9 +5856,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "skrifa"
-version = "0.22.3"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -5844,6 +5912,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "spirv"
@@ -5873,6 +5944,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5886,9 +5979,9 @@ checksum = "ce5d813d71d82c4cbc1742135004e4a79fd870214c155443451c139c9470a0aa"
 
 [[package]]
 name = "swash"
-version = "0.1.19"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+checksum = "f745de914febc7c9ab4388dfaf94bbc87e69f57bb41133a9b0c84d4be49856f3"
 dependencies = [
  "skrifa",
  "yazi",
@@ -5897,9 +5990,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5934,14 +6027,14 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.32.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
+ "objc2-core-foundation",
  "windows 0.57.0",
 ]
 
@@ -5981,13 +6074,12 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.5.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb893bff0f80ae17d3a57e030622a967b8dbc90e38284d9b4b1442e23873c94"
+checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
 dependencies = [
  "arrayvec",
  "grid",
- "num-traits",
  "serde",
  "slotmap",
 ]
@@ -6099,15 +6191,6 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -6460,13 +6543,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typeid"
@@ -6598,12 +6677,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6611,6 +6692,17 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "variadics_please"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "vcpkg"
@@ -6798,12 +6890,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "23.0.1"
+version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.9.0",
+ "cfg_aliases",
  "document-features",
  "js-sys",
  "log",
@@ -6823,14 +6916,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.1"
+version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
 dependencies = [
  "arrayvec",
  "bit-vec 0.8.0",
  "bitflags 2.9.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "document-features",
  "indexmap",
  "log",
@@ -6841,16 +6934,16 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.1"
+version = "24.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6859,7 +6952,7 @@ dependencies = [
  "bitflags 2.9.0",
  "block",
  "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
@@ -6876,6 +6969,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
+ "ordered-float",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -6883,7 +6977,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -6893,12 +6987,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
  "bitflags 2.9.0",
  "js-sys",
+ "log",
+ "serde",
  "web-sys",
 ]
 
@@ -7438,7 +7534,7 @@ dependencies = [
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -7575,9 +7671,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yazi"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
@@ -7605,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "zeno"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,19 @@ name = "simple"
 required-features = ["pixelstreaming"]
 
 [dependencies]
-bevy_app = "0.15"
-bevy_ecs = "0.15"
-bevy_render = "0.15"
-bevy_asset = "0.15"
-bevy_image = "0.15"
-bevy_log = "0.15"
-bevy_input = "0.15"
-bevy_picking = "0.15"
-bevy_math = "0.15"
-bevy_window = "0.15"
-bevy_utils = "0.15"
-bevy_capture = "0.2"
+bevy_app = { version = "0.16" }
+bevy_ecs = { version = "0.16" }
+bevy_render = { version = "0.16" }
+bevy_asset = { version = "0.16" }
+bevy_image = { version = "0.16" }
+bevy_log = { version = "0.16" }
+bevy_input = { version = "0.16" }
+bevy_picking = { version = "0.16" }
+bevy_math = { version = "0.16" }
+bevy_window = { version = "0.16" }
+bevy_utils = { version = "0.16" }
+bevy_derive = { version = "0.16" }
+bevy_platform = { version = "0.16" }
 crossbeam-channel = "0.5"
 
 ## GSTREAMER
@@ -42,7 +43,6 @@ gst-plugin-webrtc = "0.13.3"
 gst-plugin-rtp = "0.13.3"
 anyhow = "1"
 derive_more = { version = "1", features = ["display", "error"] }
-
 
 tokio = { version = "1", features = [
     "fs",
@@ -64,7 +64,7 @@ url = { version = "2", optional = true }
 byteorder = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
-bevy = "0.15"
+bevy = { version = "0.16" }
 
 [features]
 default = ["pixelstreaming"]

--- a/examples/simple/cursor.rs
+++ b/examples/simple/cursor.rs
@@ -24,7 +24,7 @@ fn setup(
 
     let mut spawnpos = (0.0, 0.0);
 
-    if let Some(position) = q_window.single().cursor_position() {
+    if let Some(position) = q_window.single().unwrap().cursor_position() {
         spawnpos = (position.x, position.y);
     }
 
@@ -43,13 +43,13 @@ fn setup(
 fn update_cursor_camera(
     mut commands: Commands,
     q_camera: Query<Entity, With<Camera>>,
-    q_cursor: Query<Entity, (With<Cursor>, Without<TargetCamera>)>,
+    q_cursor: Query<Entity, (With<Cursor>, Without<UiTargetCamera>)>,
 ) {
     if let Some(cursor_entity) = q_cursor.iter().next() {
         if let Some(camera_entity) = q_camera.iter().next() {
             commands
                 .entity(cursor_entity)
-                .insert(TargetCamera(camera_entity));
+                .insert(UiTargetCamera(camera_entity));
         }
     }
 }
@@ -65,7 +65,7 @@ fn update_cursor_position(
         .filter(|event| matches!(event, WindowEvent::CursorMoved(..)))
         .last()
     {
-        let cursor = cursor.as_mut();
+        let cursor = cursor.as_mut().unwrap();
         cursor.top = Val::Px(cursor_moved.position.y);
         cursor.left = Val::Px(cursor_moved.position.x);
     }

--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -1,8 +1,5 @@
 use bevy::{
-    app::{RunMode, ScheduleRunnerPlugin},
-    prelude::*,
-    render::RenderPlugin,
-    time::TimeUpdateStrategy,
+    app::ScheduleRunnerPlugin, prelude::*, render::RenderPlugin, time::TimeUpdateStrategy,
     winit::WinitPlugin,
 };
 use bevy_streaming::{
@@ -29,9 +26,10 @@ fn main() -> AppExit {
                 ..default()
             }),
         // Add the ScheduleRunnerPlugin to run the app in loop mode
-        ScheduleRunnerPlugin {
-            run_mode: RunMode::Loop { wait: None },
-        },
+        ScheduleRunnerPlugin::run_loop(
+            // Run 60 times per second.
+            Duration::from_secs_f64(1.0 / 60.0),
+        ),
         StreamerPlugin,
         CameraControllerPlugin,
         CursorPlugin,

--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -108,7 +108,7 @@ fn setup_cameras(mut commands: Commands, mut streamer: StreamerHelper) {
             left: Val::Px(12.0),
             ..default()
         },
-        TargetCamera(main_camera),
+        UiTargetCamera(main_camera),
     ));
 }
 
@@ -164,10 +164,11 @@ fn update_player_position_and_spectator_view(
         (With<SpectatorCamera>, Without<Player>),
     >,
 ) {
-    let camera_transform = q_player_camera_transform.single();
-    let mut spectator_camera_transform = q_spectator_camera_transform.single_mut();
-    let mut player_position = q_player_transform.single_mut();
+    let camera_transform = q_player_camera_transform.single().unwrap();
+    let mut player_position = q_player_transform.single_mut().unwrap();
 
     player_position.translation = camera_transform.translation;
+
+    let mut spectator_camera_transform = q_spectator_camera_transform.single_mut().unwrap();
     spectator_camera_transform.look_at(camera_transform.translation, Vec3::Y);
 }

--- a/src/capture/driver.rs
+++ b/src/capture/driver.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::sync::atomic::Ordering;
 
 use bevy_ecs::prelude::*;
 use bevy_log::prelude::*;
@@ -10,6 +10,8 @@ use bevy_render::{
     },
     renderer::{RenderContext, RenderDevice, RenderQueue},
 };
+
+use crate::capture::{ReleaseBufferSignal, SendBufferJob, WorkerSendBuffer};
 
 use super::Captures;
 
@@ -56,10 +58,36 @@ impl render_graph::Node for CaptureDriver {
                 (src_image.size.width as usize / block_dimensions.0 as usize) * block_size as usize,
             );
 
+            // Choose an available buffer
+
+            // we add 1 to start checking the next buffer
+            let current = capture.current.load(Ordering::Acquire) + 1;
+
+            let mut chosen = None;
+            for i in 0..capture.buffers.len() {
+                let idx = (current + i) % capture.buffers.len();
+                let buf = &capture.buffers[idx];
+                if !buf.in_use.load(Ordering::Acquire) {
+                    chosen = Some((idx, buf.clone()));
+                    break;
+                }
+            }
+
+            let Some((idx, buf)) = chosen else {
+                info!("All buffers busy, skipping frame");
+                capture.skip.store(true, Ordering::Release);
+                continue;
+            };
+            capture.skip.store(false, Ordering::Release);
+
+            capture.current.store(idx, Ordering::Release);
+
+            buf.in_use.store(true, Ordering::Release);
+
             encoder.copy_texture_to_buffer(
                 src_image.texture.as_image_copy(),
                 TexelCopyBufferInfo {
-                    buffer: &capture.buffer,
+                    buffer: &buf.buffer,
                     layout: TexelCopyBufferLayout {
                         offset: 0,
                         bytes_per_row: Some(
@@ -77,155 +105,67 @@ impl render_graph::Node for CaptureDriver {
         let render_queue = world.get_resource::<RenderQueue>().unwrap();
         render_queue.submit(std::iter::once(encoder.finish()));
 
-        // render_context.render_device().poll(Maintain::Wait);
-        // render_device.poll(Maintain::Wait);
-
         Ok(())
     }
 }
 
-// /// runs in render world after Render stage to send image from buffer via channel (receiver is in main world)
-// pub fn receive_image_from_buffer(mut captures: ResMut<Captures>, render_device: Res<RenderDevice>) {
-//     for capture in captures.0.iter_mut() {
-//         if !capture.enabled() {
-//             continue;
-//         }
-
-//         // Finally time to get our data back from the gpu.
-//         // First we get a buffer slice which represents a chunk of the buffer (which we
-//         // can't access yet).
-//         // We want the whole thing so use unbounded range.
-//         let buffer_slice = capture.buffer.slice(..);
-
-//         // Now things get complicated. WebGPU, for safety reasons, only allows either the GPU
-//         // or CPU to access a buffer's contents at a time. We need to "map" the buffer which means
-//         // flipping ownership of the buffer over to the CPU and making access legal. We do this
-//         // with `BufferSlice::map_async`.
-//         //
-//         // The problem is that map_async is not an async function so we can't await it. What
-//         // we need to do instead is pass in a closure that will be executed when the slice is
-//         // either mapped or the mapping has failed.
-//         //
-//         // The problem with this is that we don't have a reliable way to wait in the main
-//         // code for the buffer to be mapped and even worse, calling get_mapped_range or
-//         // get_mapped_range_mut prematurely will cause a panic, not return an error.
-//         //
-//         // Using channels solves this as awaiting the receiving of a message from
-//         // the passed closure will force the outside code to wait. It also doesn't hurt
-//         // if the closure finishes before the outside code catches up as the message is
-//         // buffered and receiving will just pick that up.
-//         //
-//         // It may also be worth noting that although on native, the usage of asynchronous
-//         // channels is wholly unnecessary, for the sake of portability to Wasm
-//         // we'll use async channels that work on both native and Wasm.
-
-//         let (s, r) = crossbeam_channel::bounded(1);
-
-//         // Maps the buffer so it can be read on the cpu
-//         buffer_slice.map_async(MapMode::Read, move |r| match r {
-//             // This will execute once the gpu is ready, so after the call to poll()
-//             Ok(r) => s.send(r).expect("Failed to send map update"),
-//             Err(err) => panic!("Failed to map buffer {err}"),
-//         });
-
-//         // In order for the mapping to be completed, one of three things must happen.
-//         // One of those can be calling `Device::poll`. This isn't necessary on the web as devices
-//         // are polled automatically but natively, we need to make sure this happens manually.
-//         // `Maintain::Wait` will cause the thread to wait on native but not on WebGpu.
-
-//         // This blocks until the gpu is done executing everything
-//         render_device.poll(Maintain::wait()).panic_on_timeout();
-
-//         // This blocks until the buffer is mapped
-//         r.recv().expect("Failed to receive the map_async message");
-
-//         // This could fail on app exit, if Main world clears resources (including receiver) while Render world still renders
-//         // let _ = sender.send(buffer_slice.get_mapped_range().to_vec());
-
-//         let data = buffer_slice.get_mapped_range().to_vec();
-//         capture
-//             .encoder
-//             .push_buffer(&data)
-//             .expect("Unable to push buffer to encoder");
-
-//         // We need to make sure all `BufferView`'s are dropped before we do what we're about
-//         // to do.
-//         // Unmap so that we can copy to the staging buffer in the next iteration.
-//         capture.buffer.unmap();
-//     }
-// }
-
-/// Optimized: batches GPU -> CPU buffer reads for all active captures in one render stage frame
-pub fn receive_image_from_buffer(mut captures: ResMut<Captures>, render_device: Res<RenderDevice>) {
-    use crossbeam_channel::bounded;
-
-    let mut receivers = Vec::new();
-    let mut buffer_slices = Vec::new();
-
-    for capture in captures.0.iter_mut() {
+pub fn receive_image_from_buffer(
+    mut captures: ResMut<Captures>,
+    render_device: Res<RenderDevice>,
+    worker: Res<WorkerSendBuffer>,
+) {
+    for (capture_idx, capture) in captures.0.iter_mut().enumerate() {
         if !capture.enabled() {
             continue;
         }
 
-        let buffer_slice = capture.buffer.slice(..);
-        let (sender, receiver) = bounded(1);
+        let skip = capture.skip.load(Ordering::Acquire);
+        if skip {
+            // info!("Skipping frame");
+            continue;
+        }
 
-        // info!("Map async");
-        buffer_slice.map_async(MapMode::Read, move |result| match result {
-            Ok(_) => {
-                // info!("Map async done");
-                sender.send(()).expect("Failed to send map completion")
+        let current = capture.current.load(Ordering::Acquire);
+        let buf = &capture.buffers[current];
+
+        let slice = buf.buffer.slice(..);
+
+        slice.map_async(MapMode::Read, {
+            let buffer = buf.buffer.clone();
+            let encoder = capture.encoder.clone();
+            let in_use = buf.in_use.clone();
+            let worker_tx = worker.tx.clone();
+            move |result| match result {
+                Ok(_) => {
+                    let job = SendBufferJob {
+                        buffer,
+                        encoder,
+                        capture_idx,
+                        buffer_idx: current,
+                    };
+                    if let Err(e) = worker_tx.send(job) {
+                        error!("Worker channel closed: {:?}", e);
+                    }
+                }
+                Err(err) => {
+                    error!("Failed to map buffer: {err}");
+                    in_use.store(false, Ordering::Release);
+                }
             }
-            Err(err) => panic!("Failed to map buffer: {err}"),
         });
 
-        receivers.push(receiver);
-        buffer_slices.push((
-            capture.encoder.appsrc.clone(),
-            &capture.buffer,
-            buffer_slice,
-        ));
+        render_device.poll(Maintain::Poll);
     }
+}
 
-    if !receivers.is_empty() {
-        let start = Instant::now();
-        let timeout = Duration::from_millis(1000); // Ajustable
-
-        loop {
-            render_device.poll(Maintain::Poll);
-
-            // Check if all receivers are ready
-            let all_ready = receivers.iter().all(|r| r.try_recv().is_ok());
-
-            if all_ready {
-                break;
-            }
-
-            if start.elapsed() > timeout {
-                panic!("Timeout while waiting for GPU buffer mapping");
-            }
-
-            std::thread::sleep(Duration::from_millis(1));
-        }
-
-        info!("All ready");
-
-        for (appsrc, buffer, buffer_slice) in buffer_slices {
-            let data = buffer_slice.get_mapped_range().to_vec();
-            let mut gst_buffer = gst::Buffer::with_size(data.len()).unwrap();
-            {
-                info!("Copying buffer");
-                let buffer = gst_buffer.get_mut().unwrap();
-                buffer.copy_from_slice(0, &data).unwrap();
-                info!("Buffer copied");
-            }
-
-            let _ = appsrc.push_buffer(gst_buffer);
-            info!("Buffer sent");
-
-            buffer.unmap();
-        }
-
-        info!("Finished sending buffers");
+pub fn release_mapped_buffers(
+    captures: Res<Captures>,
+    release_buffer_signal: Res<ReleaseBufferSignal>,
+) {
+    while let Ok(signal) = release_buffer_signal.rx.try_recv() {
+        let capture = &captures[signal.capture_idx];
+        let buf = &capture.buffers[signal.buffer_idx];
+        buf.buffer.unmap();
+        buf.in_use.store(false, Ordering::Release);
     }
 }

--- a/src/capture/driver.rs
+++ b/src/capture/driver.rs
@@ -1,0 +1,231 @@
+use std::time::{Duration, Instant};
+
+use bevy_ecs::prelude::*;
+use bevy_log::prelude::*;
+use bevy_render::{
+    render_asset::RenderAssets,
+    render_graph::{self, NodeRunError, RenderGraphContext, RenderLabel},
+    render_resource::{
+        CommandEncoderDescriptor, Maintain, MapMode, TexelCopyBufferInfo, TexelCopyBufferLayout,
+    },
+    renderer::{RenderContext, RenderDevice, RenderQueue},
+};
+
+use super::Captures;
+
+/// `RenderGraph` label for `CaptureNode`
+#[derive(Debug, PartialEq, Eq, Clone, Hash, RenderLabel)]
+pub struct CaptureLabel;
+
+/// `RenderGraph` node
+#[derive(Default)]
+pub struct CaptureDriver;
+
+// Copies image content from render target to buffer
+impl render_graph::Node for CaptureDriver {
+    fn run(
+        &self,
+        _graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let captures = world.get_resource::<Captures>().unwrap();
+        let gpu_images = world
+            .get_resource::<RenderAssets<bevy_render::texture::GpuImage>>()
+            .unwrap();
+
+        let mut encoder = render_context
+            .render_device()
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+
+        for capture in captures.iter() {
+            if !capture.enabled() {
+                continue;
+            }
+
+            let src_image = gpu_images.get(&capture.src_image).unwrap();
+
+            let block_dimensions = src_image.texture_format.block_dimensions();
+            let block_size = src_image.texture_format.block_copy_size(None).unwrap();
+
+            // Calculating correct size of image row because
+            // copy_texture_to_buffer can copy image only by rows aligned wgpu::COPY_BYTES_PER_ROW_ALIGNMENT
+            // That's why image in buffer can be little bit wider
+            // This should be taken into account at copy from buffer stage
+            let padded_bytes_per_row = RenderDevice::align_copy_bytes_per_row(
+                (src_image.size.width as usize / block_dimensions.0 as usize) * block_size as usize,
+            );
+
+            encoder.copy_texture_to_buffer(
+                src_image.texture.as_image_copy(),
+                TexelCopyBufferInfo {
+                    buffer: &capture.buffer,
+                    layout: TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(
+                            std::num::NonZero::<u32>::new(padded_bytes_per_row as u32)
+                                .unwrap()
+                                .into(),
+                        ),
+                        rows_per_image: None,
+                    },
+                },
+                src_image.size,
+            );
+        }
+
+        let render_queue = world.get_resource::<RenderQueue>().unwrap();
+        render_queue.submit(std::iter::once(encoder.finish()));
+
+        // render_context.render_device().poll(Maintain::Wait);
+        // render_device.poll(Maintain::Wait);
+
+        Ok(())
+    }
+}
+
+// /// runs in render world after Render stage to send image from buffer via channel (receiver is in main world)
+// pub fn receive_image_from_buffer(mut captures: ResMut<Captures>, render_device: Res<RenderDevice>) {
+//     for capture in captures.0.iter_mut() {
+//         if !capture.enabled() {
+//             continue;
+//         }
+
+//         // Finally time to get our data back from the gpu.
+//         // First we get a buffer slice which represents a chunk of the buffer (which we
+//         // can't access yet).
+//         // We want the whole thing so use unbounded range.
+//         let buffer_slice = capture.buffer.slice(..);
+
+//         // Now things get complicated. WebGPU, for safety reasons, only allows either the GPU
+//         // or CPU to access a buffer's contents at a time. We need to "map" the buffer which means
+//         // flipping ownership of the buffer over to the CPU and making access legal. We do this
+//         // with `BufferSlice::map_async`.
+//         //
+//         // The problem is that map_async is not an async function so we can't await it. What
+//         // we need to do instead is pass in a closure that will be executed when the slice is
+//         // either mapped or the mapping has failed.
+//         //
+//         // The problem with this is that we don't have a reliable way to wait in the main
+//         // code for the buffer to be mapped and even worse, calling get_mapped_range or
+//         // get_mapped_range_mut prematurely will cause a panic, not return an error.
+//         //
+//         // Using channels solves this as awaiting the receiving of a message from
+//         // the passed closure will force the outside code to wait. It also doesn't hurt
+//         // if the closure finishes before the outside code catches up as the message is
+//         // buffered and receiving will just pick that up.
+//         //
+//         // It may also be worth noting that although on native, the usage of asynchronous
+//         // channels is wholly unnecessary, for the sake of portability to Wasm
+//         // we'll use async channels that work on both native and Wasm.
+
+//         let (s, r) = crossbeam_channel::bounded(1);
+
+//         // Maps the buffer so it can be read on the cpu
+//         buffer_slice.map_async(MapMode::Read, move |r| match r {
+//             // This will execute once the gpu is ready, so after the call to poll()
+//             Ok(r) => s.send(r).expect("Failed to send map update"),
+//             Err(err) => panic!("Failed to map buffer {err}"),
+//         });
+
+//         // In order for the mapping to be completed, one of three things must happen.
+//         // One of those can be calling `Device::poll`. This isn't necessary on the web as devices
+//         // are polled automatically but natively, we need to make sure this happens manually.
+//         // `Maintain::Wait` will cause the thread to wait on native but not on WebGpu.
+
+//         // This blocks until the gpu is done executing everything
+//         render_device.poll(Maintain::wait()).panic_on_timeout();
+
+//         // This blocks until the buffer is mapped
+//         r.recv().expect("Failed to receive the map_async message");
+
+//         // This could fail on app exit, if Main world clears resources (including receiver) while Render world still renders
+//         // let _ = sender.send(buffer_slice.get_mapped_range().to_vec());
+
+//         let data = buffer_slice.get_mapped_range().to_vec();
+//         capture
+//             .encoder
+//             .push_buffer(&data)
+//             .expect("Unable to push buffer to encoder");
+
+//         // We need to make sure all `BufferView`'s are dropped before we do what we're about
+//         // to do.
+//         // Unmap so that we can copy to the staging buffer in the next iteration.
+//         capture.buffer.unmap();
+//     }
+// }
+
+/// Optimized: batches GPU -> CPU buffer reads for all active captures in one render stage frame
+pub fn receive_image_from_buffer(mut captures: ResMut<Captures>, render_device: Res<RenderDevice>) {
+    use crossbeam_channel::bounded;
+
+    let mut receivers = Vec::new();
+    let mut buffer_slices = Vec::new();
+
+    for capture in captures.0.iter_mut() {
+        if !capture.enabled() {
+            continue;
+        }
+
+        let buffer_slice = capture.buffer.slice(..);
+        let (sender, receiver) = bounded(1);
+
+        // info!("Map async");
+        buffer_slice.map_async(MapMode::Read, move |result| match result {
+            Ok(_) => {
+                // info!("Map async done");
+                sender.send(()).expect("Failed to send map completion")
+            }
+            Err(err) => panic!("Failed to map buffer: {err}"),
+        });
+
+        receivers.push(receiver);
+        buffer_slices.push((
+            capture.encoder.appsrc.clone(),
+            &capture.buffer,
+            buffer_slice,
+        ));
+    }
+
+    if !receivers.is_empty() {
+        let start = Instant::now();
+        let timeout = Duration::from_millis(1000); // Ajustable
+
+        loop {
+            render_device.poll(Maintain::Poll);
+
+            // Check if all receivers are ready
+            let all_ready = receivers.iter().all(|r| r.try_recv().is_ok());
+
+            if all_ready {
+                break;
+            }
+
+            if start.elapsed() > timeout {
+                panic!("Timeout while waiting for GPU buffer mapping");
+            }
+
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        info!("All ready");
+
+        for (appsrc, buffer, buffer_slice) in buffer_slices {
+            let data = buffer_slice.get_mapped_range().to_vec();
+            let mut gst_buffer = gst::Buffer::with_size(data.len()).unwrap();
+            {
+                info!("Copying buffer");
+                let buffer = gst_buffer.get_mut().unwrap();
+                buffer.copy_from_slice(0, &data).unwrap();
+                info!("Buffer copied");
+            }
+
+            let _ = appsrc.push_buffer(gst_buffer);
+            info!("Buffer sent");
+
+            buffer.unmap();
+        }
+
+        info!("Finished sending buffers");
+    }
+}

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,12 +1,8 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
-
 use bevy_asset::{RenderAssetUsages, prelude::*};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
 use bevy_image::prelude::*;
+use bevy_log::prelude::*;
 use bevy_render::{
     Extract,
     camera::RenderTarget,
@@ -15,6 +11,11 @@ use bevy_render::{
         TextureUsages,
     },
     renderer::RenderDevice,
+};
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use crate::gst_webrtc_encoder::GstWebRtcEncoder;
@@ -29,13 +30,49 @@ pub fn capture_extract(mut commands: Commands, captures: Extract<Query<&Capture>
     commands.insert_resource(Captures(captures.iter().cloned().collect::<Vec<Capture>>()));
 }
 
+#[derive(Clone)]
+struct CaptureBuffer {
+    buffer: Buffer,
+    in_use: Arc<AtomicBool>,
+}
+
 /// Used by `CaptureDriver` for copying from render target to buffer
 #[derive(Clone, Component)]
 pub struct Capture {
-    buffer: Buffer,
+    buffers: Vec<CaptureBuffer>,
+    current: Arc<AtomicUsize>,
+    skip: Arc<AtomicBool>,
+
     enabled: Arc<AtomicBool>,
     src_image: Handle<Image>,
-    encoder: GstWebRtcEncoder,
+    encoder: Arc<GstWebRtcEncoder>,
+}
+
+pub struct SendBufferJob {
+    // slice: BufferSlice<'static>,
+    buffer: Buffer,
+    // len: usize,
+    encoder: Arc<GstWebRtcEncoder>,
+    // in_use: Arc<AtomicBool>,
+    capture_idx: usize,
+    buffer_idx: usize,
+}
+
+#[derive(Resource, Clone)]
+pub struct WorkerSendBuffer {
+    pub tx: Sender<SendBufferJob>,
+}
+
+#[derive(Resource, Clone)]
+pub struct ReleaseBufferSignal {
+    pub rx: Receiver<ReleaseSignal>,
+}
+
+pub struct ReleaseSignal {
+    // index of the capture
+    capture_idx: usize,
+    // index of the buffer to release
+    buffer_idx: usize,
 }
 
 impl Capture {
@@ -48,18 +85,28 @@ impl Capture {
         let padded_bytes_per_row =
             RenderDevice::align_copy_bytes_per_row((size.width) as usize) * 4;
 
-        let cpu_buffer = render_device.create_buffer(&BufferDescriptor {
-            label: None,
-            size: padded_bytes_per_row as u64 * size.height as u64,
-            usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
+        let buffers = (0..3) // triple buffering
+            .map(|_| {
+                let buffer = render_device.create_buffer(&BufferDescriptor {
+                    label: Some("Capture buffer"),
+                    size: padded_bytes_per_row as u64 * size.height as u64,
+                    usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+                    mapped_at_creation: false,
+                });
+                CaptureBuffer {
+                    buffer,
+                    in_use: Arc::new(AtomicBool::new(false)),
+                }
+            })
+            .collect();
 
         Self {
-            buffer: cpu_buffer,
-            src_image,
+            buffers,
+            current: Arc::new(AtomicUsize::new(0)),
+            skip: Arc::new(AtomicBool::new(false)),
             enabled: Arc::new(AtomicBool::new(true)),
-            encoder,
+            src_image,
+            encoder: Arc::new(encoder),
         }
     }
 
@@ -96,16 +143,6 @@ pub fn setup_render_target(
         TextureUsages::COPY_SRC | TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING;
     let render_target_image_handle = images.add(render_target_image);
 
-    // This is the texture that will be copied to.
-    // let cpu_image = Image::new_fill(
-    //     size,
-    //     TextureDimension::D2,
-    //     &[0; 4],
-    //     TextureFormat::bevy_default(),
-    //     RenderAssetUsages::default(),
-    // );
-    // let cpu_image_handle = images.add(cpu_image);
-
     commands.spawn(Capture::new(
         render_target_image_handle.clone(),
         size,
@@ -116,4 +153,27 @@ pub fn setup_render_target(
     // commands.spawn(ImageToSave(cpu_image_handle));
 
     RenderTarget::Image(render_target_image_handle.into())
+}
+
+pub fn spawn_worker() -> (Sender<SendBufferJob>, Receiver<ReleaseSignal>) {
+    let (tx_job, rx_job) = unbounded::<SendBufferJob>();
+    let (tx_release, rx_release) = unbounded::<ReleaseSignal>();
+
+    std::thread::spawn(move || {
+        while let Ok(job) = rx_job.recv() {
+            let slice = job.buffer.slice(..);
+            let data = slice.get_mapped_range().to_vec();
+
+            let _ = job.encoder.push_buffer(&data);
+
+            if let Err(e) = tx_release.send(ReleaseSignal {
+                capture_idx: job.capture_idx,
+                buffer_idx: job.buffer_idx,
+            }) {
+                error!("Release channel closed: {:?}", e);
+            }
+        }
+    });
+
+    (tx_job, rx_release)
 }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,0 +1,119 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use bevy_asset::{RenderAssetUsages, prelude::*};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::prelude::*;
+use bevy_image::prelude::*;
+use bevy_render::{
+    Extract,
+    camera::RenderTarget,
+    render_resource::{
+        Buffer, BufferDescriptor, BufferUsages, Extent3d, TextureDimension, TextureFormat,
+        TextureUsages,
+    },
+    renderer::RenderDevice,
+};
+
+use crate::gst_webrtc_encoder::GstWebRtcEncoder;
+pub mod driver;
+
+/// `Captures` aggregator in `RenderWorld`
+#[derive(Clone, Default, Resource, Deref, DerefMut)]
+pub struct Captures(pub Vec<Capture>);
+
+/// Extracting `Capture`s into render world, because `ImageCopyDriver` accesses them
+pub fn capture_extract(mut commands: Commands, captures: Extract<Query<&Capture>>) {
+    commands.insert_resource(Captures(captures.iter().cloned().collect::<Vec<Capture>>()));
+}
+
+/// Used by `CaptureDriver` for copying from render target to buffer
+#[derive(Clone, Component)]
+pub struct Capture {
+    buffer: Buffer,
+    enabled: Arc<AtomicBool>,
+    src_image: Handle<Image>,
+    encoder: GstWebRtcEncoder,
+}
+
+impl Capture {
+    pub fn new(
+        src_image: Handle<Image>,
+        size: Extent3d,
+        render_device: &RenderDevice,
+        encoder: GstWebRtcEncoder,
+    ) -> Self {
+        let padded_bytes_per_row =
+            RenderDevice::align_copy_bytes_per_row((size.width) as usize) * 4;
+
+        let cpu_buffer = render_device.create_buffer(&BufferDescriptor {
+            label: None,
+            size: padded_bytes_per_row as u64 * size.height as u64,
+            usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            buffer: cpu_buffer,
+            src_image,
+            enabled: Arc::new(AtomicBool::new(true)),
+            encoder,
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+}
+
+/// Setups render target and cpu image for saving, changes scene state into render mode
+pub fn setup_render_target(
+    commands: &mut Commands,
+    images: &mut ResMut<Assets<Image>>,
+    render_device: &Res<RenderDevice>,
+    // render_instance: &Res<RenderInstance>,
+    width: u32,
+    height: u32,
+    encoder: GstWebRtcEncoder,
+) -> RenderTarget {
+    let size = Extent3d {
+        width,
+        height,
+        ..Default::default()
+    };
+
+    // This is the texture that will be rendered to.
+    let mut render_target_image = Image::new_fill(
+        size,
+        TextureDimension::D2,
+        &[0; 4],
+        TextureFormat::bevy_default(),
+        RenderAssetUsages::default(),
+    );
+    render_target_image.texture_descriptor.usage |=
+        TextureUsages::COPY_SRC | TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING;
+    let render_target_image_handle = images.add(render_target_image);
+
+    // This is the texture that will be copied to.
+    // let cpu_image = Image::new_fill(
+    //     size,
+    //     TextureDimension::D2,
+    //     &[0; 4],
+    //     TextureFormat::bevy_default(),
+    //     RenderAssetUsages::default(),
+    // );
+    // let cpu_image_handle = images.add(cpu_image);
+
+    commands.spawn(Capture::new(
+        render_target_image_handle.clone(),
+        size,
+        render_device,
+        encoder,
+    ));
+
+    // commands.spawn(ImageToSave(cpu_image_handle));
+
+    RenderTarget::Image(render_target_image_handle.into())
+}

--- a/src/gst_webrtc_encoder/mod.rs
+++ b/src/gst_webrtc_encoder/mod.rs
@@ -50,7 +50,6 @@ pub struct GstWebRtcEncoder {
     pipeline: gst::Pipeline,
     pub appsrc: gst_app::AppSrc,
     pub webrtcsink: BaseWebRTCSink,
-    started: bool,
 }
 
 impl GstWebRtcEncoder {
@@ -79,8 +78,8 @@ impl GstWebRtcEncoder {
             .max_bytes((settings.width * settings.height * 4).into())
             .build();
 
-        let queue = gst::ElementFactory::make("queue").build()?;
-        queue.set_property_from_str("leaky", "downstream");
+        // let queue = gst::ElementFactory::make("queue").build()?;
+        // queue.set_property_from_str("leaky", "downstream");
 
         let videoconvert = gst::ElementFactory::make("videoconvert").build()?;
 
@@ -105,13 +104,13 @@ impl GstWebRtcEncoder {
 
         pipeline.add_many([
             appsrc.upcast_ref(),
-            &queue,
+            // &queue,
             &videoconvert,
             webrtcsink.upcast_ref(),
         ])?;
         gst::Element::link_many([
             appsrc.upcast_ref(),
-            &queue,
+            // &queue,
             &videoconvert,
             webrtcsink.upcast_ref(),
         ])?;
@@ -121,14 +120,12 @@ impl GstWebRtcEncoder {
             pipeline,
             appsrc,
             webrtcsink,
-            started: false,
         })
     }
 
-    pub fn start(&mut self) -> Result<()> {
+    pub fn start(&self) -> Result<()> {
         info!("Start pipeline");
         self.pipeline.set_state(gst::State::Playing)?;
-        self.started = true;
 
         Ok(())
     }
@@ -164,11 +161,7 @@ impl GstWebRtcEncoder {
         Ok(())
     }
 
-    pub fn push_buffer(&mut self, data: &Vec<u8>) -> anyhow::Result<()> {
-        if !self.started {
-            self.start()?;
-        }
-
+    pub fn push_buffer(&self, data: &Vec<u8>) -> anyhow::Result<()> {
         let mut buffer = gst::Buffer::with_size(data.len()).unwrap();
         {
             let buffer = buffer.get_mut().unwrap();

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -23,7 +23,7 @@ pub struct StreamerHelper<'w, 's> {
 
 impl<'w, 's> StreamerHelper<'w, 's> {
     pub fn new_streamer_camera(&mut self, settings: StreamerSettings) -> impl Bundle {
-        let mut encoder = GstWebRtcEncoder::with_settings(settings.clone())
+        let encoder = GstWebRtcEncoder::with_settings(settings.clone())
             .expect("Unable to create gst encoder");
         encoder.start().expect("Unable to start pipeline");
 

--- a/src/pixelstreaming/controller.rs
+++ b/src/pixelstreaming/controller.rs
@@ -1,4 +1,4 @@
-use bevy_utils::HashMap;
+use bevy_platform::collections::HashMap;
 use crossbeam_channel::Receiver;
 
 use super::handler::PSMessageHandler;


### PR DESCRIPTION
Double buffering increase performances on NVIDIA, because on this architecture, the mapping of the buffer was too slow.

So, copying the buffer to CPU asynchronously can now be done while the next frame is being rendered.

I removed capture dependency to have more flexibility on buffer's management.

Upgrade to latest Bevy for latest improvements.